### PR TITLE
Removed curly brace array access for > PHP 7.4 use

### DIFF
--- a/src/GifCreator/AnimGif.php
+++ b/src/GifCreator/AnimGif.php
@@ -206,9 +206,9 @@ class AnimGif
 				$this->transparent_color = imagecolortransparent($resourceImg);
 			}
 
-			for ($j = (13 + 3 * (2 << (ord($this->frameSources[$i] { 10 }) & 0x07))), $k = TRUE; $k; $j++) {
+			for ($j = (13 + 3 * (2 << (ord($this->frameSources[$i][10]) & 0x07))), $k = TRUE; $k; $j++) {
 			 
-				switch ($this->frameSources[$i] { $j }) {
+				switch ($this->frameSources[$i][$j]) {
 				    
 					case '!':
 		    				if ((substr($this->frameSources[$i], ($j + 3), 8)) == 'NETSCAPE') {
@@ -295,9 +295,9 @@ class AnimGif
 	{
 		$cmap = 0;
 
-		if (ord($this->frameSources[0] { 10 }) & 0x80) {
+		if (ord($this->frameSources[0][10]) & 0x80) {
 		  
-			$cmap = 3 * (2 << (ord($this->frameSources[0] { 10 }) & 0x07));
+			$cmap = 3 * (2 << (ord($this->frameSources[0][10]) & 0x07));
 
 			$this->gif .= substr($this->frameSources[0], 6, 7);
 			$this->gif .= substr($this->frameSources[0], 13, $cmap);
@@ -314,26 +314,26 @@ class AnimGif
 	 */
 	protected function addGifFrames($i, $d)
 	{
-		$Locals_str = 13 + 3 * (2 << (ord($this->frameSources[ $i ] { 10 }) & 0x07));
+		$Locals_str = 13 + 3 * (2 << (ord($this->frameSources[ $i ][10]) & 0x07));
 
 		$Locals_end = strlen($this->frameSources[$i]) - $Locals_str - 1;
 		$Locals_tmp = substr($this->frameSources[$i], $Locals_str, $Locals_end);
 
-		$Global_len = 2 << (ord($this->frameSources[0 ] { 10 }) & 0x07);
-		$Locals_len = 2 << (ord($this->frameSources[$i] { 10 }) & 0x07);
+		$Global_len = 2 << (ord($this->frameSources[0][10]) & 0x07);
+		$Locals_len = 2 << (ord($this->frameSources[$i][10]) & 0x07);
 
-		$Global_rgb = substr($this->frameSources[ 0], 13, 3 * (2 << (ord($this->frameSources[ 0] { 10 }) & 0x07)));
-		$Locals_rgb = substr($this->frameSources[$i], 13, 3 * (2 << (ord($this->frameSources[$i] { 10 }) & 0x07)));
+		$Global_rgb = substr($this->frameSources[ 0], 13, 3 * (2 << (ord($this->frameSources[0][10]) & 0x07)));
+		$Locals_rgb = substr($this->frameSources[$i], 13, 3 * (2 << (ord($this->frameSources[$i][10]) & 0x07)));
 
 		$Locals_ext = "!\xF9\x04" . chr(($this->dis << 2) + 0) . word2bin($d) . "\x0\x0";
 
-		if ($this->transparent_color > -1 && ord($this->frameSources[$i] { 10 }) & 0x80) {
+		if ($this->transparent_color > -1 && ord($this->frameSources[$i][10]) & 0x80) {
 		  
-			for ($j = 0; $j < (2 << (ord($this->frameSources[$i] { 10 } ) & 0x07)); $j++) {
+			for ($j = 0; $j < (2 << (ord($this->frameSources[$i][10]) & 0x07)); $j++) {
 			 
-				if (ord($Locals_rgb { 3 * $j + 0 }) == (($this->transparent_color >> 16) & 0xFF) &&
-					ord($Locals_rgb { 3 * $j + 1 }) == (($this->transparent_color >> 8) & 0xFF) &&
-					ord($Locals_rgb { 3 * $j + 2 }) == (($this->transparent_color >> 0) & 0xFF)
+				if (ord($Locals_rgb[ 3 * $j + 0 ]) == (($this->transparent_color >> 16) & 0xFF) &&
+					ord($Locals_rgb[ 3 * $j + 1 ]) == (($this->transparent_color >> 8) & 0xFF) &&
+					ord($Locals_rgb[ 3 * $j + 2 ]) == (($this->transparent_color >> 0) & 0xFF)
 				) {
 					$Locals_ext = "!\xF9\x04".chr(($this->dis << 2) + 1).chr(($d >> 0) & 0xFF).chr(($d >> 8) & 0xFF).chr($j)."\x0";
 					break;
@@ -341,7 +341,7 @@ class AnimGif
 			}
 		}
         
-		switch ($Locals_tmp { 0 }) {
+		switch ($Locals_tmp[0]) {
 		  
 			case '!':
             
@@ -358,7 +358,7 @@ class AnimGif
 				break;
 		}
         
-		if (ord($this->frameSources[$i] { 10 }) & 0x80 && $this->imgBuilt) {
+		if (ord($this->frameSources[$i][10]) & 0x80 && $this->imgBuilt) {
 		  
 			if ($Global_len == $Locals_len) {
 			 
@@ -368,21 +368,21 @@ class AnimGif
                     
 				} else {
 				    
-					$byte = ord($Locals_img { 9 });
+					$byte = ord($Locals_img[9]);
 					$byte |= 0x80;
 					$byte &= 0xF8;
-					$byte |= (ord($this->frameSources[0] { 10 }) & 0x07);
-					$Locals_img { 9 } = chr($byte);
+					$byte |= (ord($this->frameSources[0][10]) & 0x07);
+					$Locals_img[9] = chr($byte);
 					$this->gif .= $Locals_ext.$Locals_img.$Locals_rgb.$Locals_tmp;
 				}
                 
 			} else {
 			 
-				$byte = ord($Locals_img { 9 });
+				$byte = ord($Locals_img[9]);
 				$byte |= 0x80;
 				$byte &= 0xF8;
-				$byte |= (ord($this->frameSources[$i] { 10 }) & 0x07);
-				$Locals_img { 9 } = chr($byte);
+				$byte |= (ord($this->frameSources[$i][10]) & 0x07);
+				$Locals_img[9] = chr($byte);
 				$this->gif .= $Locals_ext.$Locals_img.$Locals_rgb.$Locals_tmp;
 			}
             


### PR DESCRIPTION
As outlined in the RFC - https://wiki.php.net/rfc/deprecate_curly_braces_array_access

array access via curly braces is now deprecated.

And for people searching this issue in the future:

ErrorException: Array and string offset access syntax with curly braces is deprecated in AnimGif.php:206